### PR TITLE
get devtools out of the way

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { trpcReact, trpcReactClient } from "./trpc"
 import { RouterProvider, createRouter } from "@tanstack/react-router"
 import { DatabaseProvider } from "./data"
 import { routeTree } from "./routeTree.gen"
+import { trpcReact, trpcReactClient } from "./trpc"
 
 const queryClient = new QueryClient()
 // Import the generated route tree

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -6,7 +6,7 @@ export const Route = createRootRoute({
   component: () => (
     <Layout>
       <Outlet />
-      <TanStackRouterDevtools initialIsOpen={false} position="bottom-right"/>
+      <TanStackRouterDevtools initialIsOpen={false} position="bottom-right" />
     </Layout>
   ),
 })


### PR DESCRIPTION
removes query tool, moves router out of navigation.

we can determine which is more important and keep just that one since it creates clutter otherwise