### PR TITLE
:bug: ensure that space form renders correctly

### DIFF
--- a/apps/web/src/ui/spaces/creator.tsx
+++ b/apps/web/src/ui/spaces/creator.tsx
@@ -1,6 +1,6 @@
 import { Space, User } from "@coat-rack/core/models"
 import { Plus } from "@coat-rack/icons/regular"
-import { ProvideSpace } from "@coat-rack/sdk"
+import { getSpaceStyles } from "@coat-rack/sdk"
 import { Button } from "@coat-rack/ui/components/button"
 import {
   Dialog,
@@ -51,6 +51,8 @@ export function SpaceCreator({
     setChanged(true)
   }
 
+  const spaceStyles= getSpaceStyles(space)
+
   return (
     <>
       <Dialog>
@@ -63,7 +65,7 @@ export function SpaceCreator({
           </DialogTrigger>
         </div>
         <DialogContent>
-          <ProvideSpace space={space.id}>
+          <div style={spaceStyles}>
             <DialogHeader>
               <DialogTitle className="text-primary">
                 create {space.name || "new space"}
@@ -89,7 +91,7 @@ export function SpaceCreator({
                 <Plus className="h-4 w-4 fill-current" />
               </Button>
             </DialogFooter>
-          </ProvideSpace>
+          </div>
         </DialogContent>
       </Dialog>
     </>

--- a/apps/web/src/ui/spaces/editor.tsx
+++ b/apps/web/src/ui/spaces/editor.tsx
@@ -1,6 +1,6 @@
 import { Space, User } from "@coat-rack/core/models"
 import { Check, Pencil, Save } from "@coat-rack/icons/regular"
-import { ProvideSpace } from "@coat-rack/sdk"
+import { getSpaceStyles } from "@coat-rack/sdk"
 import { Button } from "@coat-rack/ui/components/button"
 import {
   Dialog,
@@ -42,6 +42,8 @@ export function SpaceEditor({
     setUpdated(space)
   }
 
+  const spaceStyles = getSpaceStyles(space)
+
   return (
     <>
       <Dialog>
@@ -61,7 +63,7 @@ export function SpaceEditor({
           </DialogTrigger>
         </div>
         <DialogContent>
-          <ProvideSpace space={updated.id}>
+          <div style={spaceStyles} >
             <DialogHeader>
               <DialogTitle className="text-primary">
                 editing {updated.name}
@@ -98,7 +100,7 @@ export function SpaceEditor({
                 )}
               </Button>
             </DialogFooter>
-          </ProvideSpace>
+          </div>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
The space forms should not use the `ProvideSpace` as this is intended for apps that are rendering space related content. It is also dependant on the app data being provided which isn't done at the level where we're trying to access it. Since we're very specifically accessing the styles this implementation makes sense