### PR TITLE
Ensure consistent handling of spaces

### DIFF
--- a/.changeset/quiet-cases-lay.md
+++ b/.changeset/quiet-cases-lay.md
@@ -1,0 +1,7 @@
+---
+"@coat-rack/core": patch
+"@coat-rack/sdk": patch
+"@coat-rack/web": patch
+---
+
+Consistent handling of spaces and local user data

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { RouterProvider, createRouter } from "@tanstack/react-router"
-import { DatabaseProvider } from "./data"
+import { LoggedInContextProvider } from "./logged-in-context"
 import { routeTree } from "./routeTree.gen"
 import { trpcReact, trpcReactClient } from "./trpc"
 
@@ -29,9 +29,9 @@ function App() {
   return (
     <trpcReact.Provider client={trpcReactClient} queryClient={queryClient}>
       <QueryClientProvider client={queryClient}>
-        <DatabaseProvider>
+        <LoggedInContextProvider>
           <RouterProvider router={router} />
-        </DatabaseProvider>
+        </LoggedInContextProvider>
       </QueryClientProvider>
     </trpcReact.Provider>
   )

--- a/apps/web/src/db/local.ts
+++ b/apps/web/src/db/local.ts
@@ -1,11 +1,13 @@
 import { useObservable } from "@coat-rack/core/async"
-import { KeyValue, Space } from "@coat-rack/core/models"
+import { KeyValue, Space, User } from "@coat-rack/core/models"
 import { map } from "rxjs"
 import { localDB } from "./rxdb"
 
 export const USER_META_KEY = "user"
 
-export const ACTIVE_SPACE_META_KEY = "space"
+export const SELECTED_SPACE_META_KEY = "space"
+
+export const USER_SPACE_META_KEY = "user-space"
 
 export const FILTER_SPACES_META_KEY = "filter-spaces"
 
@@ -13,41 +15,64 @@ interface Meta<T> extends KeyValue {
   value: T
 }
 
-export const setLocalUser = (username?: string) =>
-  localDB.meta.upsertLocal<Meta<string | undefined>>(USER_META_KEY, {
+export const setLocalUser = (user?: User) =>
+  localDB.meta.upsertLocal<Meta<User | undefined>>(USER_META_KEY, {
     id: USER_META_KEY,
-    value: username,
+    value: user,
   })
 
 export const useLocalUser = () =>
   useObservable(
     localDB.meta
-      .getLocal$<Meta<string | undefined>>(USER_META_KEY)
+      .getLocal$<Meta<User>>(USER_META_KEY)
       .pipe(map((result) => result?._data.data.value)),
     [],
   )
 
-export const setActiveSpace = (space: Space) =>
-  localDB.meta.upsertLocal<Meta<Space>>(ACTIVE_SPACE_META_KEY, {
-    id: ACTIVE_SPACE_META_KEY,
+export const setLocalUserSpace = (space?: Space) =>
+  localDB.meta.upsertLocal<Meta<Space | undefined>>(USER_SPACE_META_KEY, {
+    id: USER_SPACE_META_KEY,
     value: space,
   })
 
-export const useActiveSpace = () =>
+export const useLocalUserSpace = () =>
   useObservable(
     localDB.meta
-      .getLocal$<Meta<Space>>(ACTIVE_SPACE_META_KEY)
+      .getLocal$<Meta<Space>>(USER_SPACE_META_KEY)
       .pipe(map((result) => result?._data.data.value)),
     [],
   )
 
-export const setFilterSpaces = (active: boolean) =>
+export const setLocalSelectedSpace = (space?: Space) =>
+  localDB.meta.upsertLocal<Meta<Space | undefined>>(SELECTED_SPACE_META_KEY, {
+    id: SELECTED_SPACE_META_KEY,
+    value: space,
+  })
+
+export const useLocalSelectedSpace = () =>
+  useObservable(
+    localDB.meta
+      .getLocal$<Meta<Space>>(SELECTED_SPACE_META_KEY)
+      .pipe(map((result) => result?._data.data.value)),
+    [],
+  )
+
+export const useLocalActiveSpace = () => {
+  const userSpace = useLocalUserSpace()
+  const selectedSpace = useLocalSelectedSpace()
+
+  const resolvedSpace = selectedSpace || userSpace
+
+  return resolvedSpace
+}
+
+export const setLocalFilterSpaces = (active: boolean) =>
   localDB.meta.upsertLocal<Meta<boolean>>(FILTER_SPACES_META_KEY, {
     id: FILTER_SPACES_META_KEY,
     value: active,
   })
 
-export const useFilterSpaces = () =>
+export const useLocalFilterSpaces = () =>
   useObservable(
     localDB.meta
       .getLocal$<Meta<boolean>>(FILTER_SPACES_META_KEY)

--- a/apps/web/src/db/local.ts
+++ b/apps/web/src/db/local.ts
@@ -15,67 +15,30 @@ interface Meta<T> extends KeyValue {
   value: T
 }
 
-export const setLocalUser = (user?: User) =>
-  localDB.meta.upsertLocal<Meta<User | undefined>>(USER_META_KEY, {
-    id: USER_META_KEY,
-    value: user,
-  })
-
-export const useLocalUser = () =>
-  useObservable(
+const useLocalMetaStore = <T>(key: string) => {
+  const value = useObservable(
     localDB.meta
-      .getLocal$<Meta<User>>(USER_META_KEY)
+      .getLocal$<Meta<T>>(key)
       .pipe(map((result) => result?._data.data.value)),
     [],
   )
 
-export const setLocalUserSpace = (space?: Space) =>
-  localDB.meta.upsertLocal<Meta<Space | undefined>>(USER_SPACE_META_KEY, {
-    id: USER_SPACE_META_KEY,
-    value: space,
-  })
+  const setValue = (value?: T) =>
+    localDB.meta.upsertLocal<Meta<T | undefined>>(key, {
+      id: key,
+      value,
+    })
 
-export const useLocalUserSpace = () =>
-  useObservable(
-    localDB.meta
-      .getLocal$<Meta<Space>>(USER_SPACE_META_KEY)
-      .pipe(map((result) => result?._data.data.value)),
-    [],
-  )
-
-export const setLocalSelectedSpace = (space?: Space) =>
-  localDB.meta.upsertLocal<Meta<Space | undefined>>(SELECTED_SPACE_META_KEY, {
-    id: SELECTED_SPACE_META_KEY,
-    value: space,
-  })
-
-export const useLocalSelectedSpace = () =>
-  useObservable(
-    localDB.meta
-      .getLocal$<Meta<Space>>(SELECTED_SPACE_META_KEY)
-      .pipe(map((result) => result?._data.data.value)),
-    [],
-  )
-
-export const useLocalActiveSpace = () => {
-  const userSpace = useLocalUserSpace()
-  const selectedSpace = useLocalSelectedSpace()
-
-  const resolvedSpace = selectedSpace || userSpace
-
-  return resolvedSpace
+  return [value, setValue] as const
 }
 
-export const setLocalFilterSpaces = (active: boolean) =>
-  localDB.meta.upsertLocal<Meta<boolean>>(FILTER_SPACES_META_KEY, {
-    id: FILTER_SPACES_META_KEY,
-    value: active,
-  })
+export const useLocalUser = () => useLocalMetaStore<User>(USER_META_KEY)
+
+export const useLocalUserSpace = () =>
+  useLocalMetaStore<Space>(USER_SPACE_META_KEY)
+
+export const useLocalSelectedSpace = () =>
+  useLocalMetaStore<Space>(SELECTED_SPACE_META_KEY)
 
 export const useLocalFilterSpaces = () =>
-  useObservable(
-    localDB.meta
-      .getLocal$<Meta<boolean>>(FILTER_SPACES_META_KEY)
-      .pipe(map((result) => result?._data.data.value || false)),
-    [],
-  )
+  useLocalMetaStore<boolean>(FILTER_SPACES_META_KEY)

--- a/apps/web/src/iframe/rpc.ts
+++ b/apps/web/src/iframe/rpc.ts
@@ -1,4 +1,4 @@
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { useChannelSubscription } from "@coat-rack/core/messaging"
 import { ChannelMessage } from "@coat-rack/core/messsage"
 import { RpcRequest, RpcResponse, err, ok } from "@coat-rack/core/rpc"

--- a/apps/web/src/iframe/rpc.ts
+++ b/apps/web/src/iframe/rpc.ts
@@ -1,4 +1,4 @@
-import { useDatabase } from "@/data"
+import { useLoggedInContext } from "@/data"
 import { useChannelSubscription } from "@coat-rack/core/messaging"
 import { ChannelMessage } from "@coat-rack/core/messsage"
 import { RpcRequest, RpcResponse, err, ok } from "@coat-rack/core/rpc"
@@ -25,7 +25,7 @@ export function useIFrameRPC(
   space: string,
   filtered: boolean,
 ) {
-  const { db } = useDatabase()
+  const { db } = useLoggedInContext()
 
   const handler = (
     event: RpcRequest<Db<unknown>>,

--- a/apps/web/src/iframe/spaces.ts
+++ b/apps/web/src/iframe/spaces.ts
@@ -1,5 +1,4 @@
-import { useDatabase } from "@/data"
-import { useActiveSpace, useFilterSpaces } from "@/db/local"
+import { useLoggedInContext } from "@/data"
 import { useObservable } from "@coat-rack/core/async"
 import { useChannelSubscription } from "@coat-rack/core/messaging"
 import {
@@ -10,15 +9,13 @@ import { SharedChannel } from "@coat-rack/core/shared-channel"
 import { useEffect } from "react"
 
 export const useIFrameSpaces = (channel: SharedChannel) => {
-  const { db } = useDatabase()
+  const { db, filterSpaces, activeSpace } = useLoggedInContext()
   const spaces = useObservable(db.spaces.find({}).$)
-  const active = useActiveSpace()
-  const filtered = useFilterSpaces()
 
   const message: SpacesResponseMessage = {
     type: "meta.spaces-response",
-    active,
-    filtered: filtered || false,
+    active: activeSpace,
+    filtered: filterSpaces || false,
     all: spaces?.map((space) => space._data) || [],
   }
 
@@ -30,5 +27,5 @@ export const useIFrameSpaces = (channel: SharedChannel) => {
 
   useEffect(() => {
     channel.postMessage(message)
-  }, [spaces, active, filtered])
+  }, [spaces, activeSpace, filterSpaces])
 }

--- a/apps/web/src/iframe/spaces.ts
+++ b/apps/web/src/iframe/spaces.ts
@@ -1,4 +1,4 @@
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { useObservable } from "@coat-rack/core/async"
 import { useChannelSubscription } from "@coat-rack/core/messaging"
 import {

--- a/apps/web/src/iframe/synchronized.tsx
+++ b/apps/web/src/iframe/synchronized.tsx
@@ -1,7 +1,7 @@
 import { createMessageChannelForParent } from "@coat-rack/core/messaging"
 import { useMemo, useRef } from "react"
-import { useIFrameRPC } from "./iframe/rpc"
-import { useIFrameSpaces } from "./iframe/spaces"
+import { useIFrameRPC } from "./rpc"
+import { useIFrameSpaces } from "./spaces"
 
 interface SynchronizedIframeProps {
   appId: string

--- a/apps/web/src/layout.tsx
+++ b/apps/web/src/layout.tsx
@@ -2,11 +2,11 @@ import { useObservable } from "@coat-rack/core/async"
 import { Button } from "@coat-rack/ui/components/button"
 import { Link } from "@tanstack/react-router"
 import { PropsWithChildren } from "react"
-import { useDatabase } from "./data"
+import { useLoggedInContext } from "./data"
 import { Navigation } from "./ui/navigation"
 
 export const Layout = ({ children }: PropsWithChildren) => {
-  const { signOut, db } = useDatabase()
+  const { signOut, db } = useLoggedInContext()
   const apps = useObservable(db.apps.find({}).$)
 
   return (

--- a/apps/web/src/layout.tsx
+++ b/apps/web/src/layout.tsx
@@ -2,7 +2,7 @@ import { useObservable } from "@coat-rack/core/async"
 import { Button } from "@coat-rack/ui/components/button"
 import { Link } from "@tanstack/react-router"
 import { PropsWithChildren } from "react"
-import { useLoggedInContext } from "./data"
+import { useLoggedInContext } from "./logged-in-context"
 import { Navigation } from "./ui/navigation"
 
 export const Layout = ({ children }: PropsWithChildren) => {

--- a/apps/web/src/routes/apps/$id.lazy.tsx
+++ b/apps/web/src/routes/apps/$id.lazy.tsx
@@ -1,6 +1,5 @@
 import { SynchronizedIframe } from "@/SynchronizedIFrame"
-import { useDatabase } from "@/data"
-import { useActiveSpace, useFilterSpaces, useLocalUser } from "@/db/local"
+import { useLoggedInContext } from "@/data"
 import { useObservable } from "@coat-rack/core/async"
 import { createLazyFileRoute } from "@tanstack/react-router"
 
@@ -21,13 +20,8 @@ function Index() {
   sandboxHost.pathname = ""
   const { id } = Route.useParams()
 
-  const user = useLocalUser()
-  const activeSpace = useActiveSpace()
-  const filtered = useFilterSpaces()
+  const { db, activeSpace, filterSpaces } = useLoggedInContext()
 
-  const space = activeSpace?.id || user
-
-  const { db } = useDatabase()
   const app = useObservable(
     db.apps.findOne({
       selector: {
@@ -37,7 +31,7 @@ function Index() {
     [id],
   )
 
-  const hasConfig = app && space
+  const hasConfig = app && activeSpace
   if (!hasConfig) {
     return undefined
   }
@@ -50,8 +44,8 @@ function Index() {
         className="h-full w-full"
         appId={app.id}
         appUrl={appUrl}
-        filteredSpaces={filtered || false}
-        space={space}
+        filteredSpaces={filterSpaces || false}
+        space={activeSpace.id}
       />
     </div>
   )

--- a/apps/web/src/routes/apps/$id.lazy.tsx
+++ b/apps/web/src/routes/apps/$id.lazy.tsx
@@ -1,5 +1,5 @@
-import { SynchronizedIframe } from "@/SynchronizedIFrame"
-import { useLoggedInContext } from "@/data"
+import { SynchronizedIframe } from "@/iframe/synchronized"
+import { useLoggedInContext } from "@/logged-in-context"
 import { useObservable } from "@coat-rack/core/async"
 import { createLazyFileRoute } from "@tanstack/react-router"
 

--- a/apps/web/src/routes/apps/index.lazy.tsx
+++ b/apps/web/src/routes/apps/index.lazy.tsx
@@ -1,6 +1,6 @@
 import { createLazyFileRoute } from "@tanstack/react-router"
 
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { trpcClient } from "@/trpc"
 import { AppInstaller } from "@/ui/apps/installer"
 import { AppManager } from "@/ui/apps/manager"

--- a/apps/web/src/routes/apps/index.lazy.tsx
+++ b/apps/web/src/routes/apps/index.lazy.tsx
@@ -1,6 +1,6 @@
 import { createLazyFileRoute } from "@tanstack/react-router"
 
-import { useDatabase } from "@/data"
+import { useLoggedInContext } from "@/data"
 import { trpcClient } from "@/trpc"
 import { AppInstaller } from "@/ui/apps/installer"
 import { AppManager } from "@/ui/apps/manager"
@@ -12,7 +12,7 @@ export const Route = createLazyFileRoute("/apps/")({
 })
 
 function Index() {
-  const { db, appsCollection } = useDatabase()
+  const { db, appsCollection } = useLoggedInContext()
 
   const [createKey, setCreateKey] = useState(Date.now())
 

--- a/apps/web/src/routes/index.lazy.tsx
+++ b/apps/web/src/routes/index.lazy.tsx
@@ -1,4 +1,4 @@
-import { useDatabase } from "@/data"
+import { useLoggedInContext } from "@/data"
 import { useObservable } from "@coat-rack/core/async"
 import { Link, createLazyFileRoute } from "@tanstack/react-router"
 
@@ -7,7 +7,7 @@ export const Route = createLazyFileRoute("/")({
 })
 
 function Index() {
-  const { db } = useDatabase()
+  const { db } = useLoggedInContext()
   const apps = useObservable(db.apps.find({}).$)
 
   return (

--- a/apps/web/src/routes/index.lazy.tsx
+++ b/apps/web/src/routes/index.lazy.tsx
@@ -1,4 +1,4 @@
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { useObservable } from "@coat-rack/core/async"
 import { Link, createLazyFileRoute } from "@tanstack/react-router"
 

--- a/apps/web/src/routes/spaces/index.lazy.tsx
+++ b/apps/web/src/routes/spaces/index.lazy.tsx
@@ -1,7 +1,6 @@
 import { createLazyFileRoute } from "@tanstack/react-router"
 
-import { useDatabase } from "@/data"
-import { useLocalUser } from "@/db/local"
+import { useLoggedInContext } from "@/data"
 import { SpaceCreator } from "@/ui/spaces/creator"
 import { SpaceEditor } from "@/ui/spaces/editor"
 import { useObservable } from "@coat-rack/core/async"
@@ -13,13 +12,11 @@ export const Route = createLazyFileRoute("/spaces/")({
 })
 
 function Index() {
-  const { db, spacesCollection } = useDatabase()
+  const { db, spacesCollection, user } = useLoggedInContext()
   const users = useObservable(db.users.find({}).$)
   const spaces = useObservable(db.spaces.find({}).$)
 
   const [createKey, setCreateKey] = useState(Date.now())
-
-  const user = useLocalUser()
 
   const upsertSpace = async (space: Space) => {
     setCreateKey(Date.now())
@@ -37,14 +34,14 @@ function Index() {
             <SpaceCreator
               key={createKey}
               appUsers={users || []}
-              user={user}
+              user={user.id}
               onSubmit={upsertSpace}
             />
           )}
         </div>
         <div className="flex flex-col">
           {spaces
-            ?.filter((s) => s.owner === user)
+            ?.filter((s) => s.owner === user.id)
             ?.map((space) => (
               <SpaceEditor
                 key={space.id}
@@ -59,7 +56,7 @@ function Index() {
           <h2 className="text-xl">Shared Spaces</h2>
           <ol>
             {spaces
-              ?.filter((s) => s.owner !== user)
+              ?.filter((s) => s.owner !== user.id)
               ?.map((s) => (
                 <li key={s.id} style={{ color: s.color }}>
                   {s.name}

--- a/apps/web/src/routes/spaces/index.lazy.tsx
+++ b/apps/web/src/routes/spaces/index.lazy.tsx
@@ -1,6 +1,6 @@
 import { createLazyFileRoute } from "@tanstack/react-router"
 
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { SpaceCreator } from "@/ui/spaces/creator"
 import { SpaceEditor } from "@/ui/spaces/editor"
 import { useObservable } from "@coat-rack/core/async"

--- a/apps/web/src/ui/apps/installer.tsx
+++ b/apps/web/src/ui/apps/installer.tsx
@@ -1,4 +1,4 @@
-import { useActiveSpace } from "@/db/local"
+import { useLoggedInContext } from "@/data"
 import { Plus } from "@coat-rack/icons/regular"
 import { getSpaceStyles } from "@coat-rack/sdk"
 import { Button } from "@coat-rack/ui/components/button"
@@ -20,10 +20,10 @@ export function AppInstaller({
 }: {
   onSubmit: (url: string) => void
 }) {
-  const space = useActiveSpace()
+  const { activeSpace } = useLoggedInContext()
   const [url, setUrl] = useState("")
 
-  const spaceStyles = getSpaceStyles(space)
+  const spaceStyles = getSpaceStyles(activeSpace)
 
   const handleSubmit = async () => {
     onSubmit(url)

--- a/apps/web/src/ui/apps/installer.tsx
+++ b/apps/web/src/ui/apps/installer.tsx
@@ -1,4 +1,4 @@
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { Plus } from "@coat-rack/icons/regular"
 import { getSpaceStyles } from "@coat-rack/sdk"
 import { Button } from "@coat-rack/ui/components/button"

--- a/apps/web/src/ui/apps/manager.tsx
+++ b/apps/web/src/ui/apps/manager.tsx
@@ -1,4 +1,4 @@
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { App } from "@coat-rack/core/models"
 import { Pencil } from "@coat-rack/icons/regular"
 import { getSpaceStyles } from "@coat-rack/sdk"

--- a/apps/web/src/ui/apps/manager.tsx
+++ b/apps/web/src/ui/apps/manager.tsx
@@ -1,4 +1,4 @@
-import { useActiveSpace } from "@/db/local"
+import { useLoggedInContext } from "@/data"
 import { App } from "@coat-rack/core/models"
 import { Pencil } from "@coat-rack/icons/regular"
 import { getSpaceStyles } from "@coat-rack/sdk"
@@ -22,9 +22,9 @@ export function AppManager({
   app: App
   setDevMode: (devMode: boolean) => void
 }) {
-  const space = useActiveSpace()
+  const { activeSpace } = useLoggedInContext()
 
-  const spaceStyles = getSpaceStyles(space)
+  const spaceStyles = getSpaceStyles(activeSpace)
 
   return (
     <Dialog>

--- a/apps/web/src/ui/login/form.tsx
+++ b/apps/web/src/ui/login/form.tsx
@@ -30,15 +30,23 @@ export const LoginForm = ({ onLogin, logIn, signUp }: Props) => {
       .catch(() => setError("Invalid username"))
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        handleLogIn()
+      }}
+      className="flex flex-col gap-4 p-4"
+    >
       <h1 className="font-title text-5xl">Login</h1>
 
       <Input onChange={(e) => setUsername(e.target.value)} value={username} />
 
-      <Button onClick={handleLogIn}>Log In</Button>
-      <Button onClick={handleSignUp}>Sign Up</Button>
+      <Button type="submit">Log In</Button>
+      <Button type="button" onClick={handleSignUp}>
+        Sign Up
+      </Button>
 
       <div>{error && <p className="text-red-500">{error}</p>}</div>
-    </div>
+    </form>
   )
 }

--- a/apps/web/src/ui/login/form.tsx
+++ b/apps/web/src/ui/login/form.tsx
@@ -1,0 +1,44 @@
+import { User } from "@coat-rack/core/models"
+import { Button } from "@coat-rack/ui/components/button"
+import { Input } from "@coat-rack/ui/components/input"
+import { useState } from "react"
+
+interface Props {
+  onLogin: (user: User) => void
+  logIn: (username: string) => Promise<User | undefined>
+  signUp: (username: string) => Promise<User>
+}
+
+export const LoginForm = ({ onLogin, logIn, signUp }: Props) => {
+  const [username, setUsername] = useState("")
+  const [error, setError] = useState("")
+
+  const handleLogIn = () =>
+    logIn(username)
+      .then((result) => {
+        if (result) {
+          onLogin(result)
+        } else {
+          setError("User not found")
+        }
+      })
+      .catch(() => setError("Invalid login"))
+
+  const handleSignUp = () =>
+    signUp(username)
+      .then((user) => onLogin(user))
+      .catch(() => setError("Invalid username"))
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="font-title text-5xl">Login</h1>
+
+      <Input onChange={(e) => setUsername(e.target.value)} value={username} />
+
+      <Button onClick={handleLogIn}>Log In</Button>
+      <Button onClick={handleSignUp}>Sign Up</Button>
+
+      <div>{error && <p className="text-red-500">{error}</p>}</div>
+    </div>
+  )
+}

--- a/apps/web/src/ui/navigation.tsx
+++ b/apps/web/src/ui/navigation.tsx
@@ -1,4 +1,4 @@
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { HomeSolid, OctagonTimesSolid } from "@coat-rack/icons/solid"
 import { getSpaceStyles } from "@coat-rack/sdk"
 import { Button } from "@coat-rack/ui/components/button"

--- a/apps/web/src/ui/navigation.tsx
+++ b/apps/web/src/ui/navigation.tsx
@@ -1,4 +1,4 @@
-import { useActiveSpace } from "@/db/local"
+import { useLoggedInContext } from "@/data"
 import { HomeSolid, OctagonTimesSolid } from "@coat-rack/icons/solid"
 import { getSpaceStyles } from "@coat-rack/sdk"
 import { Button } from "@coat-rack/ui/components/button"
@@ -13,7 +13,7 @@ export const Navigation = ({
   Links?: React.ReactNode
   signOut: () => void
 }>) => {
-  const activeSpace = useActiveSpace()
+  const { activeSpace } = useLoggedInContext()
   const spaceStyles = getSpaceStyles(activeSpace)
 
   return (

--- a/apps/web/src/ui/spaces/selector.tsx
+++ b/apps/web/src/ui/spaces/selector.tsx
@@ -4,7 +4,7 @@ import { ChartNetwork, User } from "@coat-rack/icons/regular"
 import { FilterSolid } from "@coat-rack/icons/solid"
 
 export const SpaceSelector = () => {
-  const { db, filterSpaces, activeSpace, setFilterSpaces, setActiveSpace } =
+  const { db, filterSpaces, activeSpace, setFilterSpaces, setSelectedSpace } =
     useLoggedInContext()
   const spaces = useObservable(db.spaces.find({}).$)
 
@@ -37,7 +37,7 @@ export const SpaceSelector = () => {
         ) : (
           <button
             key={space.id}
-            onClick={() => setActiveSpace(space._data)}
+            onClick={() => setSelectedSpace(space._data)}
             className="flex h-6 w-6 items-center justify-center"
             style={{ backgroundColor: space.color }}
             title={space.name}

--- a/apps/web/src/ui/spaces/selector.tsx
+++ b/apps/web/src/ui/spaces/selector.tsx
@@ -1,4 +1,4 @@
-import { useLoggedInContext } from "@/data"
+import { useLoggedInContext } from "@/logged-in-context"
 import { useObservable } from "@coat-rack/core/async"
 import { ChartNetwork, User } from "@coat-rack/icons/regular"
 import { FilterSolid } from "@coat-rack/icons/solid"

--- a/apps/web/src/ui/spaces/selector.tsx
+++ b/apps/web/src/ui/spaces/selector.tsx
@@ -1,19 +1,12 @@
-import { useDatabase } from "@/data"
-import {
-  setActiveSpace,
-  setFilterSpaces,
-  useActiveSpace,
-  useFilterSpaces,
-} from "@/db/local"
+import { useLoggedInContext } from "@/data"
 import { useObservable } from "@coat-rack/core/async"
 import { ChartNetwork, User } from "@coat-rack/icons/regular"
 import { FilterSolid } from "@coat-rack/icons/solid"
 
 export const SpaceSelector = () => {
-  const { db } = useDatabase()
+  const { db, filterSpaces, activeSpace, setFilterSpaces, setActiveSpace } =
+    useLoggedInContext()
   const spaces = useObservable(db.spaces.find({}).$)
-  const activeSpace = useActiveSpace()
-  const isFiltered = useFilterSpaces()
 
   if (!spaces) {
     return undefined
@@ -54,7 +47,7 @@ export const SpaceSelector = () => {
         )
       })}
 
-      {isFiltered ? (
+      {filterSpaces ? (
         <button
           title="Show all spaces"
           className="bg-primary flex h-6 w-6 items-center justify-center"

--- a/packages/core/src/messsage.ts
+++ b/packages/core/src/messsage.ts
@@ -35,7 +35,7 @@ export type SpacesRequestMessage = ChannelMessage<"meta", "spaces">
  */
 export interface SpacesResponseMessage
   extends ChannelMessage<"meta", "spaces-response"> {
-  active?: Space
+  active: Space
   all: Space[]
   filtered: boolean
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2,7 +2,7 @@ import type { ComponentType } from "react"
 
 export interface AppContext<T = unknown> {
   db: Db<T>
-  activeSpace?: Space
+  activeSpace: Space
   spaces: Space[]
 }
 


### PR DESCRIPTION
Space management/resolution is inconsistent in different parts of the app. This standardizes this to be done as follows:

1. Either via the context in logged in contexts
2. Via the login management screen that manages the context

This ensures that all parts of the app are able to resolve space and user data in a consistent manner as well as ensure that this data can be cleanly passed to the sandbox and internal apps

This also streamlines some things by storing the entire user data in the local DB and blocking login until data can be resolved. This is unfortunate but ensures that the app is loaded in a ready-to-use state

In order to improve on this we can also consider storing this "stash" data in a synchronous store that will make this data more readily accessible